### PR TITLE
Update category_choice.rb

### DIFF
--- a/app/models/category_choice.rb
+++ b/app/models/category_choice.rb
@@ -1,4 +1,4 @@
-class Category_Choice < ActiveHash::Base
+class CategoryChoice < ActiveHash::Base
   self.data = [
       {id: 1, category_choice: 'レディース'}
       {id: 2, category_choice: 'メンズ'}


### PR DESCRIPTION
# WHAT
active_hashのモデル名修正

# WHY
スネークケースとキャメルケースが混ざっており命名規則に則っていない。
そのためこのactive_hashからデータを取り出す際のエラーの原因になりうるため修正
