### PR TITLE
サーバーサイド頻出エラー（1）

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,4 +1,5 @@
 class PurchaseController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_item, only: [ :index, :pay, :done]
   before_action :set_card, only: :index
   require 'payjp'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2020_05_22_113356) do
     t.integer "price", null: false
     t.bigint "category_id"
     t.bigint "brand_id"
+    t.integer "size_id"
     t.integer "condition_id", null: false
     t.integer "postage_payer_id", null: false
     t.bigint "buyer_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,7 +68,6 @@ ActiveRecord::Schema.define(version: 2020_05_22_113356) do
     t.integer "price", null: false
     t.bigint "category_id"
     t.bigint "brand_id"
-    t.integer "size_id"
     t.integer "condition_id", null: false
     t.integer "postage_payer_id", null: false
     t.bigint "buyer_id"


### PR DESCRIPTION
 #what
サーバーサイド頻出エラーリスト（1）の解決

#why
ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせる為