### PR TITLE
購入機能の条件分岐追加

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -4,32 +4,40 @@ class PurchaseController < ApplicationController
   require 'payjp'
 
   def index
-    @sending_destination = current_user.sending_destination
-    @card = Card.where(user_id: current_user.id).first
-    if card = blank?
-      redirect_to card_new_path
+    if @item.buyer_id.nil?
+      @sending_destination = current_user.sending_destination
+      @card = Card.where(user_id: current_user.id).first
+      if card = blank?
+        redirect_to card_new_path
+      else
+        Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+        customer = Payjp::Customer.retrieve(@card.customer_id)
+        @default_card_information = customer.cards.retrieve(@card.card_id)
+      end
     else
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(@card.customer_id)
-      @default_card_information = customer.cards.retrieve(@card.card_id)
+      redirect_to root_path
     end
   end
 
   def pay
-    card = Card.where(user_id: current_user.id).first
-    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    Payjp::Charge.create(
-      amount: @item.price,
-      customer: card.customer_id,
-      currency: 'jpy',
-    )
-      redirect_to action: 'done'
+    if @item.buyer_id.nil? && @item.seller_id != current_user.id
+      card = Card.where(user_id: current_user.id).first
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      Payjp::Charge.create(
+        amount: @item.price,
+        customer: card.customer_id,
+        currency: 'jpy',
+      )
+        redirect_to action: 'done'
+    else
+      redirect_to root_path
+    end
   end
 
   def done
     @item.update(buyer_id: current_user.id)
     if @item.buyer_id.nil?
-    flash.now[:alert] = 'データの保存に失敗しました'
+      flash.now[:alert] = 'データの保存に失敗しました'
     end
   end
 


### PR DESCRIPTION
What
自分で出品した商品に購入できないように制限を設けた。
取引済の商品に購入処理を行えないように制限を設けた。

Why
自身の出品を削除機能があるので自身の商品を買う必要がない。
商品が無いのに誤って購入してしまうトラブルを防ぐため。