### PR TITLE
URL直打ち防止対策

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -2,11 +2,10 @@ class PurchaseController < ApplicationController
   before_action :authenticate_user!
   before_action :set_item, only: [ :index, :pay, :done]
   before_action :set_card, only: :index
-  before_action :correct_user, only: [:index]
   require 'payjp'
 
   def index
-    if @item.buyer_id.nil?
+    if @item.buyer_id.nil? && @item.seller_id != current_user.id
       @sending_destination = current_user.sending_destination
       @card = Card.where(user_id: current_user.id).first
       if card = blank?
@@ -45,12 +44,6 @@ class PurchaseController < ApplicationController
 
   private
 
-  def correct_user
-    @sending_destination = current_user.sending_destination
-      unless @sending_destination
-        redirect_to root_path
-      end
-  end
 
   def set_item
     @item = Item.find(params[:id])

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -2,10 +2,10 @@ class PurchaseController < ApplicationController
   before_action :authenticate_user!
   before_action :set_item, only: [ :index, :pay, :done]
   before_action :set_card, only: :index
+  before_action :correct_user, only: [:index]
   require 'payjp'
 
   def index
-    @sending_destination = current_user.sending_destination
     @card = Card.where(user_id: current_user.id).first
     if card = blank?
       redirect_to card_new_path
@@ -35,6 +35,13 @@ class PurchaseController < ApplicationController
   end
 
   private
+
+  def correct_user
+    @sending_destination = current_user.sending_destination
+      unless @sending_destination
+        redirect_to root_path
+      end
+  end
 
   def set_item
     @item = Item.find(params[:id])


### PR DESCRIPTION
# What
【サーバーサイド頻出エラーチェックリスト】
3. 自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている
6. 一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
を実装した。

# Why
自身の出品した商品や、売り切れで購入出来ない商品の購入画面へのアクセスを防止するため。