### PR TITLE
購入済みの商品から購入ボタンの削除

### DIFF
--- a/app/views/items/_buyBtn.html.haml
+++ b/app/views/items/_buyBtn.html.haml
@@ -1,4 +1,4 @@
-- if user_signed_in? && current_user.id == @item.seller_id
+- if user_signed_in? && current_user.id == @item.seller_id || @item.buyer_id
   .display-none
 - else 
   = link_to confirmation_purchase_path(@item.id), method: :get do


### PR DESCRIPTION
# What
購入済み商品から購入ボタンの削除

# Why
一度購入された商品を再度購入できないようにするため